### PR TITLE
fix: モーダル内のMarkdownが1行に潰れる問題を修正

### DIFF
--- a/.claude/scripts/kpt-viewer.py
+++ b/.claude/scripts/kpt-viewer.py
@@ -286,6 +286,7 @@ function showTab(n,el){
 function showModal(c){document.getElementById('modal-body').innerHTML=marked.parse(c);document.getElementById('modal').style.display='block';}
 function render(){
   if(!D)return;
+  window.__contents={reviews:D.reviews.map(r=>r.content||''),kpts:D.kpts.map(k=>k.content||'')};
   const pCount=Object.keys(D.activity.projects||{}).length;
   document.getElementById('stats').innerHTML=`
     <div class="stat-card"><div class="stat-value">${D.total_reviews}</div><div class="stat-label">Sessions Analyzed</div></div>
@@ -310,17 +311,20 @@ function render(){
   // Reviews
   const rl=document.getElementById('review-list');
   if(!D.reviews.length){rl.innerHTML='<div class="empty">No self-reviews yet. Complete a session to generate one.</div>';}
-  else{rl.innerHTML=D.reviews.slice().reverse().map(r=>{
+  else{rl.innerHTML=D.reviews.slice().reverse().map((r,i)=>{
+    const idx=D.reviews.length-1-i;
     if(r.error)return`<div class="entry">${r.file}: ${r.error}</div>`;
     const badge=r.issue_count>0?`<span class="entry-badge-issue">${r.issue_count} issues</span>`:`<span class="entry-badge-clean">clean</span>`;
-    return`<div class="entry" onclick='showModal(${JSON.stringify(JSON.stringify(r.content))})'>
+    return`<div class="entry" onclick="showModal(window.__contents.reviews[${idx}])">
       <span class="entry-date">${r.date} ${r.time.replace(/(\\d{2})(\\d{2})(\\d{2})/,"$1:$2:$3")}</span>
       <span class="entry-project">${r.project}</span>${badge}
       <div class="entry-summary">${r.summary}</div></div>`;}).join('');}
   // KPTs
   const kl=document.getElementById('kpt-list');
   if(!D.kpts.length){kl.innerHTML='<div class="empty">No KPT reports yet. Run /weekly-kpt to generate one.</div>';}
-  else{kl.innerHTML=D.kpts.slice().reverse().map(k=>`<div class="entry" onclick='showModal(${JSON.stringify(JSON.stringify(k.content))})'><span class="entry-date">${k.file}</span></div>`).join('');}
+  else{kl.innerHTML=D.kpts.slice().reverse().map((k,i)=>{
+    const idx=D.kpts.length-1-i;
+    return`<div class="entry" onclick="showModal(window.__contents.kpts[${idx}])"><span class="entry-date">${k.file}</span></div>`;}).join('');}
 }
 load();
 </script>


### PR DESCRIPTION
## Summary
- `showModal` への content 引数を `JSON.stringify` で**二重エスケープ**していたため、改行 (`\n`) がリテラル文字列として渡り marked.parse() で改行として解釈されず、自己分析/KPTのモーダルが1行に潰れて表示されていた
- コンテンツを `window.__contents` にインデックス付き配列で保持し、onclick からはインデックス参照に変更
- 副次効果として content 内の特殊文字（`'`, `<` など）に対しても安全になった

## Test plan
- [x] `python3 ~/.claude/scripts/kpt-viewer.py` で起動
- [x] ブラウザで http://localhost:8765 を開き、Self-Reviews タブからエントリをクリック
- [x] モーダル内で見出し・リスト・改行が正しく表示されることを確認
- [x] KPT Archive タブでも同様に表示できることを確認
- [x] Python構文チェック (`py_compile`) 通過

## Before / After
- **Before**: 全文が1行に連結されて表示
- **After**: Markdownとして見出し・箇条書き・改行が反映される