### PR TITLE
feat: Haiku 呼び出しコストの実測トラッキング追加 (#6)

### DIFF
--- a/.claude/hooks/kpt-session-analyze.sh
+++ b/.claude/hooks/kpt-session-analyze.sh
@@ -116,10 +116,41 @@ PROMPT_END
   cat "$ANALYSIS_PROMPT" "$PROMPT_FILE" > "${PROMPT_FILE}.combined"
 
   export CLAUDE_SESSION_ANALYSIS=1
-  claude -p --model haiku --no-session-persistence \
-    < "${PROMPT_FILE}.combined" > "$OUTPUT_FILE" 2>/dev/null
+  JSON_OUTPUT=$(mktemp)
+  claude -p --model haiku --output-format json --no-session-persistence \
+    < "${PROMPT_FILE}.combined" > "$JSON_OUTPUT" 2>/dev/null
 
-  rm -f "$PROMPT_FILE" "$ANALYSIS_PROMPT" "${PROMPT_FILE}.combined"
+  # JSON なら .result を分析本文として書き出し、usage を cost-logs に追記
+  if jq -e '.result' "$JSON_OUTPUT" > /dev/null 2>&1; then
+    jq -r '.result' "$JSON_OUTPUT" > "$OUTPUT_FILE"
+
+    COST_DIR="$HOME/.claude/kpt-data/cost-logs"
+    mkdir -p "$COST_DIR"
+    COST_FILE="${COST_DIR}/cost_${YEAR_MONTH}.jsonl"
+    jq -c \
+      --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+      --arg date "$(date +"%Y-%m-%d")" \
+      --arg sid "$SESSION_ID" \
+      --arg project "$PROJECT_NAME" \
+      '{
+        timestamp: $ts,
+        local_date: $date,
+        session_id: $sid,
+        project: $project,
+        model: (.modelUsage // {} | keys | .[0] // "unknown"),
+        input_tokens: (.usage.input_tokens // 0),
+        output_tokens: (.usage.output_tokens // 0),
+        cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+        cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+        cost_usd: (.total_cost_usd // 0),
+        duration_ms: (.duration_ms // 0)
+      }' "$JSON_OUTPUT" >> "$COST_FILE"
+  else
+    # JSON パース失敗時は raw を残してフォールバック
+    cp "$JSON_OUTPUT" "$OUTPUT_FILE"
+  fi
+
+  rm -f "$PROMPT_FILE" "$ANALYSIS_PROMPT" "${PROMPT_FILE}.combined" "$JSON_OUTPUT"
 
 ) </dev/null &>/dev/null &
 disown

--- a/.claude/scripts/kpt-viewer.py
+++ b/.claude/scripts/kpt-viewer.py
@@ -22,6 +22,7 @@ ACTIVITY_DIR = os.path.join(KPT_DATA, "activity-logs")
 REVIEWS_DIR = os.path.join(KPT_DATA, "session-reviews")
 KPT_DIR = os.path.join(KPT_DATA, "kpt")
 EXPERIMENTS_DIR = os.path.join(KPT_DATA, "experiments")
+COST_LOGS_DIR = os.path.join(KPT_DATA, "cost-logs")
 
 
 def load_activity_stats():
@@ -78,6 +79,65 @@ def load_activity_stats():
         p["days"] = len(p["days"])
 
     return stats
+
+
+def load_cost_stats():
+    """SessionEnd hook の Haiku 呼び出しコストを月次/直近セッション単位で集計。"""
+    monthly = {}  # "YYYY-MM" -> {input, output, cache_read, cache_creation, cost_usd, sessions}
+    sessions = []  # 直近セッション（最大 50 件）
+
+    for f in sorted(glob.glob(os.path.join(COST_LOGS_DIR, "cost_*.jsonl"))):
+        month = os.path.basename(f).replace("cost_", "").replace(".jsonl", "")
+        if month not in monthly:
+            monthly[month] = {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cost_usd": 0.0,
+                "sessions": 0,
+            }
+        try:
+            with open(f, "r") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    m = monthly[month]
+                    m["input_tokens"] += int(entry.get("input_tokens", 0) or 0)
+                    m["output_tokens"] += int(entry.get("output_tokens", 0) or 0)
+                    m["cache_read_input_tokens"] += int(entry.get("cache_read_input_tokens", 0) or 0)
+                    m["cache_creation_input_tokens"] += int(entry.get("cache_creation_input_tokens", 0) or 0)
+                    m["cost_usd"] += float(entry.get("cost_usd", 0) or 0)
+                    m["sessions"] += 1
+                    sessions.append(entry)
+        except Exception:
+            continue
+
+    # 直近セッション（timestamp 降順 / 最大 50 件）
+    sessions.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+    sessions = sessions[:50]
+
+    # 月次を月降順でリスト化
+    monthly_list = [
+        {"month": k, **v, "cost_usd": round(v["cost_usd"], 4)}
+        for k, v in sorted(monthly.items(), reverse=True)
+    ]
+
+    totals = {
+        "input_tokens": sum(m["input_tokens"] for m in monthly.values()),
+        "output_tokens": sum(m["output_tokens"] for m in monthly.values()),
+        "cache_read_input_tokens": sum(m["cache_read_input_tokens"] for m in monthly.values()),
+        "cache_creation_input_tokens": sum(m["cache_creation_input_tokens"] for m in monthly.values()),
+        "cost_usd": round(sum(m["cost_usd"] for m in monthly.values()), 4),
+        "sessions": sum(m["sessions"] for m in monthly.values()),
+    }
+
+    return {"monthly": monthly_list, "recent": sessions, "totals": totals}
 
 
 def parse_review(filepath):
@@ -381,6 +441,7 @@ def get_dashboard_data():
     burning = detect_burning_categories(reviews)
     project_issues = project_issue_distribution(reviews)
     quality_scatter = session_quality_scatter(reviews, activity)
+    costs = load_cost_stats()
 
     # hour_weekday は JSON化のため dict に
     hw = activity.pop("hour_weekday", [[0] * 24 for _ in range(7)])
@@ -401,6 +462,7 @@ def get_dashboard_data():
         "action_types": action_types,
         "total_reviews": total_reviews,
         "clean_rate": round(clean_reviews / total_reviews * 100, 1) if total_reviews else 0,
+        "costs": costs,
     }
 
 
@@ -517,6 +579,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
     <button class="tab" onclick="showTab('heatmaps',this)">Heatmaps</button>
     <button class="tab" onclick="showTab('experiments',this)">Experiments</button>
     <button class="tab" onclick="showTab('tries',this)">Tries</button>
+    <button class="tab" onclick="showTab('costs',this)">Costs</button>
     <button class="tab" onclick="showTab('reviews',this)">Self-Reviews</button>
     <button class="tab" onclick="showTab('kpts',this)">KPT Archive</button>
   </div>
@@ -562,6 +625,22 @@ DASHBOARD_HTML = """<!DOCTYPE html>
     </div>
   </div>
 
+  <div id="costs" style="display:none">
+    <div class="section">
+      <h2>Haiku Cost Tracking</h2>
+      <div class="subtitle" style="margin-bottom:16px;">SessionEnd hook が Haiku を呼び出した実測コスト（Anthropic API 課金プランのみ）。Pro/Max 定額プランではローカル計測値であり実課金ではない。</div>
+      <div class="stats-grid" id="cost-totals"></div>
+    </div>
+    <div class="section">
+      <h2>Monthly Breakdown</h2>
+      <div id="cost-monthly"></div>
+    </div>
+    <div class="section">
+      <h2>Recent Sessions (last 50)</h2>
+      <div id="cost-recent"></div>
+    </div>
+  </div>
+
   <div id="reviews" style="display:none">
     <div class="section"><h2>Session Self-Reviews</h2><div id="review-list"></div></div>
   </div>
@@ -582,7 +661,7 @@ async function load(){D=await(await fetch('/api/data')).json();render();}
 function showTab(n,el){
   document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
   el.classList.add('active');
-  ['overview','heatmaps','experiments','tries','reviews','kpts'].forEach(id=>{document.getElementById(id).style.display=id===n?'block':'none';});
+  ['overview','heatmaps','experiments','tries','costs','reviews','kpts'].forEach(id=>{document.getElementById(id).style.display=id===n?'block':'none';});
 }
 function showModal(c){document.getElementById('modal-body').innerHTML=marked.parse(c);document.getElementById('modal').style.display='block';}
 function heatColor(v,mx){if(!mx||!v)return'#1e293b';const r=v/mx;const h=220-(r*220);return`hsl(${h},70%,${35+r*20}%)`;}
@@ -716,6 +795,44 @@ function render(){
       <span class="try-title">${E(t.title)}</span>
       <span class="try-week">${E(t.week)}</span>
       <span class="try-status ${t.implemented?'done':'pending'}">${t.implemented?'✅ '+E(t.impl_date):'pending'}</span>
+    </div>`).join('');
+  }
+
+  // Costs
+  const c=D.costs||{totals:{},monthly:[],recent:[]};
+  const fmtNum=n=>(n||0).toLocaleString();
+  const fmtUsd=n=>'$'+(n||0).toFixed(4);
+  document.getElementById('cost-totals').innerHTML=`
+    <div class="stat-card"><div class="stat-value">${fmtUsd(c.totals.cost_usd)}</div><div class="stat-label">Total Cost</div></div>
+    <div class="stat-card"><div class="stat-value">${fmtNum(c.totals.sessions)}</div><div class="stat-label">Hook Invocations</div></div>
+    <div class="stat-card"><div class="stat-value">${fmtNum(c.totals.input_tokens)}</div><div class="stat-label">Input Tokens</div></div>
+    <div class="stat-card"><div class="stat-value">${fmtNum(c.totals.output_tokens)}</div><div class="stat-label">Output Tokens</div></div>
+    <div class="stat-card"><div class="stat-value">${fmtNum(c.totals.cache_read_input_tokens)}</div><div class="stat-label">Cache Read</div></div>
+    <div class="stat-card"><div class="stat-value">${fmtNum(c.totals.cache_creation_input_tokens)}</div><div class="stat-label">Cache Creation</div></div>`;
+  const cm=document.getElementById('cost-monthly');
+  if(!c.monthly.length){cm.innerHTML='<div class="empty">No cost data yet. SessionEnd hook が初回 Haiku 呼び出し以降に蓄積される。</div>';}
+  else{
+    cm.innerHTML=`<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse;font-size:0.85rem">
+      <thead><tr style="color:#94a3b8;text-align:left;border-bottom:1px solid #334155">
+        <th style="padding:8px 6px">Month</th><th style="padding:8px 6px">Sessions</th>
+        <th style="padding:8px 6px">Input</th><th style="padding:8px 6px">Output</th>
+        <th style="padding:8px 6px">Cache R/W</th><th style="padding:8px 6px">Cost</th>
+      </tr></thead><tbody>${c.monthly.map(m=>`<tr style="border-bottom:1px solid #334155">
+        <td style="padding:8px 6px"><strong>${E(m.month)}</strong></td>
+        <td style="padding:8px 6px">${fmtNum(m.sessions)}</td>
+        <td style="padding:8px 6px">${fmtNum(m.input_tokens)}</td>
+        <td style="padding:8px 6px">${fmtNum(m.output_tokens)}</td>
+        <td style="padding:8px 6px">${fmtNum(m.cache_read_input_tokens)} / ${fmtNum(m.cache_creation_input_tokens)}</td>
+        <td style="padding:8px 6px;color:#38bdf8">${fmtUsd(m.cost_usd)}</td>
+      </tr>`).join('')}</tbody></table></div>`;
+  }
+  const cr=document.getElementById('cost-recent');
+  if(!c.recent.length){cr.innerHTML='<div class="empty">No sessions logged yet.</div>';}
+  else{
+    cr.innerHTML=c.recent.map(s=>`<div class="entry">
+      <span class="entry-date">${E((s.timestamp||'').replace('T',' ').replace('Z',''))}</span>
+      <span class="entry-project">${E(s.project||'unknown')}</span>
+      <div class="entry-summary">in ${fmtNum(s.input_tokens)} / out ${fmtNum(s.output_tokens)} / cache ${fmtNum(s.cache_read_input_tokens)}+${fmtNum(s.cache_creation_input_tokens)} · ${fmtUsd(s.cost_usd)} · ${s.duration_ms||0}ms</div>
     </div>`).join('');
   }
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ python3 ~/.claude/scripts/kpt-viewer.py
 - **Heatmaps**: カテゴリ×週ヒートマップ、曜日×時間帯ヒートマップ
 - **Experiments**: `/forward-kpt` の実験カンバン（In Progress / Success / Continue / Fail）
 - **Tries**: Try寿命タイムライン（実装済み/pending）
+- **Costs**: SessionEnd hook の Haiku 呼び出し実測（月次トークン・コスト・直近セッション）
 - **Self-Reviews / KPT Archive**: 生データ閲覧
 
 ### 手動でセッション分析をテスト
@@ -129,10 +130,54 @@ sleep 15 && ls -la ~/.claude/kpt-data/session-reviews/
 ├── kpt/                     # 週次KPT結果
 │   ├── 2026-W14.md
 │   └── 2026-W15.md
-└── experiments/             # /forward-kpt: 週次Experiment
-    ├── experiment_2026-W14.md
-    └── experiment_2026-W15.md
+├── experiments/             # /forward-kpt: 週次Experiment
+│   ├── experiment_2026-W14.md
+│   └── experiment_2026-W15.md
+└── cost-logs/               # SessionEnd hook: Haiku 呼び出しの usage / cost 実測
+    ├── cost_2026-03.jsonl
+    └── cost_2026-04.jsonl
 ```
+
+## Data Flow
+
+本システムが扱うデータの流れを明示する。
+
+### ローカルに残るデータ（`~/.claude/kpt-data/` 配下）
+
+- `activity-logs/activity_YYYY-MM.jsonl` — Stop hook が書く応答ごとの軽量ログ。**API 送信なし、ローカルファイル書き込みのみ**。
+- `session-reviews/YYYY-MM/*.md` — SessionEnd hook が Claude Haiku に transcript を要約させた自己分析結果。
+- `cost-logs/cost_YYYY-MM.jsonl` — SessionEnd hook の Haiku 呼び出しごとの usage / cost（input/output/cache tokens, `total_cost_usd`, duration）を JSONL で蓄積。
+- `kpt/*.md` — `/weekly-kpt` が生成する週次 KPT 全文。
+- `experiments/*.md` — `/forward-kpt` が仕込む週次 Experiment。
+
+### Anthropic API に送信されるデータ
+
+- **SessionEnd hook** が transcript（ユーザー / assistant の発言抜粋）を整形し、**Claude Haiku** に自己分析プロンプトとして送信する（`.claude/hooks/kpt-session-analyze.sh`）。
+- 送信内容は session review に書き戻されるため、ローカルに残るデータと内容が対応する。
+
+### API 送信されないデータ
+
+- Stop hook の activity-log はローカルファイルに JSONL を追記するだけで、API 呼び出しを一切行わない。
+
+## Cost Tracking
+
+推測値ではなく**実測値**で管理する。SessionEnd hook は `claude -p --output-format json` で Haiku を呼び、応答 JSON の `usage` / `total_cost_usd` / `duration_ms` を `~/.claude/kpt-data/cost-logs/cost_YYYY-MM.jsonl` に記録する。
+
+ダッシュボードの **Costs タブ** で以下を確認できる：
+
+- 累積: total cost (USD) / hook invocations / input / output / cache read / cache creation
+- 月次ブレークダウン（month × sessions × tokens × cost）
+- 直近 50 セッションの per-call 内訳（project / tokens / cost / duration）
+
+```bash
+python3 ~/.claude/scripts/kpt-viewer.py  # → http://localhost:8765 → Costs タブ
+```
+
+> **注意**: `total_cost_usd` は Anthropic API 単価に基づく計算値であり、Pro / Max 定額プラン利用時は実課金ではなく「API 換算した場合の目安」として読むこと。課金自体は利用プランに従う。
+
+### hook を一時的に無効化する
+
+API 呼び出しを止めたい場合、`~/.claude/settings.json` から `hooks.SessionEnd` エントリを削除する。Stop hook（activity-log）は API を呼ばないため、SessionEnd だけ外す運用も可能。
 
 ## 依存
 

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ mkdir -p "$CLAUDE_DIR/kpt-data/activity-logs"
 mkdir -p "$CLAUDE_DIR/kpt-data/session-reviews"
 mkdir -p "$CLAUDE_DIR/kpt-data/kpt"
 mkdir -p "$CLAUDE_DIR/kpt-data/experiments"
+mkdir -p "$CLAUDE_DIR/kpt-data/cost-logs"
 
 # 2. Hooks
 echo "[2/6] Installing hooks..."


### PR DESCRIPTION
Closes #6

## Summary
- Issue #6 は当初「README に Cost Awareness（推測値）を書く」内容だったが、**推測値ではなく実測で管理する**方針に切り替え
- SessionEnd hook を `claude -p --output-format json` に変更し、応答 JSON の `usage` / `total_cost_usd` / `duration_ms` を `~/.claude/kpt-data/cost-logs/cost_YYYY-MM.jsonl` に蓄積
- ダッシュボード (`kpt-viewer.py`) に **Costs タブ** を追加。累計・月次・直近50セッションを閲覧可能
- README は Data Flow セクション（事実ベース）と Cost Tracking セクション（実測値 + 注意書き）に整理

## スキーマ（cost_YYYY-MM.jsonl の 1 行）
```json
{"timestamp":"2026-04-21T...","local_date":"2026-04-21","session_id":"...","project":"...","model":"claude-haiku-4-5-20251001","input_tokens":9,"output_tokens":45,"cache_read_input_tokens":0,"cache_creation_input_tokens":36758,"cost_usd":0.0465915,"duration_ms":2397}
```

## 受け入れ基準
- [x] README に Cost / Data Flow セクションがある（実測ベースで記述）
- [x] Anthropic API に送信されるデータが明示されている
- [x] Pro/Max 定額プランでは `total_cost_usd` が実課金ではない旨の注意書きあり

## Test plan
- [ ] `bash -n kpt-session-analyze.sh` / `python3 -m py_compile kpt-viewer.py` クリア済み
- [ ] `claude -p --output-format json` 単体実行で `.result` / `.usage` / `.total_cost_usd` が取れることを確認済み
- [ ] 実セッションで SessionEnd hook → `cost_YYYY-MM.jsonl` へ JSONL 追記を確認
- [ ] `python3 ~/.claude/scripts/kpt-viewer.py` → Costs タブに集計値が表示されることを確認
- [ ] JSON パース失敗時のフォールバック（raw 出力を OUTPUT_FILE にコピー）が動くことを確認