### PR TITLE
feat: uninstall.sh とバックアップ処理追加 (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,28 @@ chmod +x install.sh
 ```
 
 これだけ。インストーラーが以下を自動でやります
+- 既存の `settings.json` / `CLAUDE.md` を `~/.claude/backup-YYYYMMDD-HHMMSS/` に退避
 - `~/.claude/hooks/` にSessionEnd hookを配置
 - `~/.claude/skills/` にKPTスキルを配置
 - `~/.claude/settings.json` にhook設定をマージ（既存設定があれば安全にマージ）
 - `~/.claude/CLAUDE.md` にKPT運用ルールを追記
+
+### アンインストール
+
+```bash
+./uninstall.sh                 # 設定とファイルを削除、kpt-data は残す
+./uninstall.sh --purge-data    # データも含めて全削除
+```
+
+`uninstall.sh` は以下を実施する:
+
+- `~/.claude/backup-YYYYMMDD-HHMMSS/` に `settings.json` / `CLAUDE.md` を退避
+- `settings.json` から **KPT 関連 hook エントリのみ** を `jq` で除去（他の Stop / SessionEnd hook は保持）
+- `~/.claude/hooks/kpt-*.sh` を削除
+- `~/.claude/skills/{weekly-kpt,apply-kpt,forward-kpt}/` を削除
+- `~/.claude/scripts/kpt-viewer.py` を削除
+- `~/.claude/CLAUDE.md` から自己改善システムブロックを除去（他セクションは保持）
+- **データディレクトリ `~/.claude/kpt-data/` はデフォルト残す**（`--purge-data` 指定時のみ削除）
 
 ### 依存ツール
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,16 @@ CLAUDE_DIR="$HOME/.claude"
 echo "=== Claude Code Self-Improvement KPT ==="
 echo ""
 
+# 0. バックアップ（既存 settings.json / CLAUDE.md を変更する前に退避）
+if [ -f "$CLAUDE_DIR/settings.json" ] || [ -f "$CLAUDE_DIR/CLAUDE.md" ]; then
+  TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+  BACKUP_DIR="$CLAUDE_DIR/backup-$TIMESTAMP"
+  echo "[0/6] Backing up existing config to $BACKUP_DIR ..."
+  mkdir -p "$BACKUP_DIR"
+  [ -f "$CLAUDE_DIR/settings.json" ] && cp "$CLAUDE_DIR/settings.json" "$BACKUP_DIR/settings.json"
+  [ -f "$CLAUDE_DIR/CLAUDE.md" ] && cp "$CLAUDE_DIR/CLAUDE.md" "$BACKUP_DIR/CLAUDE.md"
+fi
+
 # 1. ディレクトリ
 echo "[1/6] Creating directories..."
 mkdir -p "$CLAUDE_DIR/hooks"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# =============================================================================
+# Claude Code Self-Improvement KPT System — Uninstaller
+# =============================================================================
+# 既存設定を壊さず、本システムで追加した hook / skill / スクリプト / CLAUDE.md
+# ブロックのみを除去する。データディレクトリはデフォルト保持。
+#
+# Usage:
+#   ./uninstall.sh                 # 設定とファイルを削除、kpt-data は残す
+#   ./uninstall.sh --purge-data    # データも含めて全削除
+# =============================================================================
+
+set -euo pipefail
+
+CLAUDE_DIR="$HOME/.claude"
+PURGE_DATA=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --purge-data) PURGE_DATA=1 ;;
+    -h|--help)
+      grep -E '^# ( |$)' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo "Usage: $0 [--purge-data]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "=== Claude Code Self-Improvement KPT — Uninstaller ==="
+echo ""
+
+# 0. バックアップ
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$CLAUDE_DIR/backup-$TIMESTAMP"
+echo "[0/6] Creating backup at $BACKUP_DIR ..."
+mkdir -p "$BACKUP_DIR"
+[ -f "$CLAUDE_DIR/settings.json" ] && cp "$CLAUDE_DIR/settings.json" "$BACKUP_DIR/settings.json"
+[ -f "$CLAUDE_DIR/CLAUDE.md" ] && cp "$CLAUDE_DIR/CLAUDE.md" "$BACKUP_DIR/CLAUDE.md"
+
+# 1. settings.json から KPT 関連 hook エントリのみ除去
+echo "[1/6] Cleaning settings.json ..."
+SETTINGS="$CLAUDE_DIR/settings.json"
+if [ -f "$SETTINGS" ] && command -v jq &> /dev/null; then
+  TEMP=$(mktemp)
+  jq '
+    def strip_kpt:
+      map(
+        .hooks |= (map(select((.command // "") | test("kpt-.*\\.sh") | not)))
+      )
+      | map(select((.hooks // []) | length > 0));
+
+    if .hooks.Stop       then .hooks.Stop       |= strip_kpt else . end
+    | if .hooks.SessionEnd then .hooks.SessionEnd |= strip_kpt else . end
+    | if (.hooks.Stop // [])       | length == 0 then del(.hooks.Stop)       else . end
+    | if (.hooks.SessionEnd // []) | length == 0 then del(.hooks.SessionEnd) else . end
+    | if (.hooks // {}) == {} then del(.hooks) else . end
+  ' "$SETTINGS" > "$TEMP" && mv "$TEMP" "$SETTINGS"
+  echo "  - Removed KPT hook entries (Stop / SessionEnd)"
+elif [ -f "$SETTINGS" ]; then
+  echo "  WARNING: jq not found. Please remove KPT hook entries manually from $SETTINGS"
+fi
+
+# 2. Hooks
+echo "[2/6] Removing hooks ..."
+rm -f "$CLAUDE_DIR/hooks/kpt-activity-log.sh"
+rm -f "$CLAUDE_DIR/hooks/kpt-session-analyze.sh"
+
+# 3. Skills
+echo "[3/6] Removing skills ..."
+rm -rf "$CLAUDE_DIR/skills/weekly-kpt"
+rm -rf "$CLAUDE_DIR/skills/apply-kpt"
+rm -rf "$CLAUDE_DIR/skills/forward-kpt"
+
+# 4. Dashboard script
+echo "[4/6] Removing dashboard script ..."
+rm -f "$CLAUDE_DIR/scripts/kpt-viewer.py"
+rm -rf "$CLAUDE_DIR/scripts/__pycache__" 2>/dev/null || true
+
+# 5. CLAUDE.md から自己改善ブロック除去
+echo "[5/6] Cleaning CLAUDE.md ..."
+CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
+if [ -f "$CLAUDE_MD" ] && grep -q '^# Claude Code 自己改善システム$' "$CLAUDE_MD"; then
+  TEMP=$(mktemp)
+  # `# Claude Code 自己改善システム` から次の H1 手前まで（見つからなければ EOF まで）を削除。
+  # 末尾に残る連続空行は pending にバッファし、次に非空行が来た時だけ吐き出すことで除去する。
+  awk '
+    /^# Claude Code 自己改善システム$/ { in_block=1; next }
+    in_block && /^# / && !/^# Claude Code 自己改善システム$/ { in_block=0 }
+    !in_block {
+      if ($0 == "") { pending=pending "\n" }
+      else { printf "%s", pending; pending=""; print }
+    }
+  ' "$CLAUDE_MD" > "$TEMP"
+  mv "$TEMP" "$CLAUDE_MD"
+  echo "  - Removed self-improvement block"
+  if [ ! -s "$CLAUDE_MD" ]; then
+    rm -f "$CLAUDE_MD"
+    echo "  - Removed empty CLAUDE.md"
+  fi
+else
+  echo "  - No KPT block found, skipping"
+fi
+
+# 6. データ
+echo "[6/6] Data directory ..."
+if [ "$PURGE_DATA" = "1" ]; then
+  rm -rf "$CLAUDE_DIR/kpt-data"
+  echo "  - Purged $CLAUDE_DIR/kpt-data (--purge-data)"
+else
+  if [ -d "$CLAUDE_DIR/kpt-data" ]; then
+    echo "  - Preserved $CLAUDE_DIR/kpt-data (use --purge-data to delete)"
+  fi
+fi
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "Backup: $BACKUP_DIR"
+echo "  - settings.json / CLAUDE.md の変更前スナップショット"
+echo ""
+if [ "$PURGE_DATA" != "1" ]; then
+  echo "Data retained: $CLAUDE_DIR/kpt-data"
+  echo "  - 完全削除したい場合: ./uninstall.sh --purge-data"
+  echo ""
+fi


### PR DESCRIPTION
Closes #5

## Summary
- `uninstall.sh` を新規追加。KPT 関連の hook / skill / スクリプト / CLAUDE.md ブロックのみを安全に除去する
- `install.sh` と `uninstall.sh` 両方で、変更前に \`~/.claude/settings.json\` / \`~/.claude/CLAUDE.md\` を \`~/.claude/backup-YYYYMMDD-HHMMSS/\` に退避
- データディレクトリ \`~/.claude/kpt-data/\` はデフォルト残し、\`--purge-data\` 指定時のみ削除
- README にアンインストール手順を追加

## 受け入れ基準
- [x] \`uninstall.sh\` が既存設定を壊さず KPT 関連のみ除去できる
- [x] \`--purge-data\` なしではデータディレクトリを削除しない
- [x] バックアップが \`~/.claude/backup-*/\` に作成される
- [x] README にアンインストール手順が記載される
- [x] インストール → アンインストール → 再インストールのサイクルが安全に回ることを手動テストで確認

## Test plan
手動検証済み（疑似 \$HOME として tmpdir を使用）:
- [x] 既存 Stop hook（ユーザーカスタム）を残したまま KPT Stop / SessionEnd hook のみ追加されること
- [x] uninstall でユーザー既存 hook / CLAUDE.md 既存セクションが保持されること
- [x] 1回目 uninstall 後、kpt-data が保持されていること
- [x] reinstall 後に settings.json / CLAUDE.md が正しく復元されること
- [x] \`--purge-data\` で kpt-data が削除されること
- [x] backup-YYYYMMDD-HHMMSS/ に settings.json / CLAUDE.md のスナップショットが作成されること

## 実装ノート
- settings.json クリーンアップは \`jq\` で \`command\` フィールドが \`kpt-*.sh\` を含むエントリのみフィルタ。ユーザー独自の Stop / SessionEnd hook はそのまま残る
- CLAUDE.md クリーンアップは awk で \`# Claude Code 自己改善システム\` から次の H1 手前（または EOF）までを削除。他セクションは保持される
- jq が未インストールの環境では警告を出して設定変更をスキップ（install.sh と同じポリシー）