### PR TITLE
feat: secret redaction フィルタとプライバシーノート追加 (#4)

### DIFF
--- a/.claude/hooks/kpt-activity-log.sh
+++ b/.claude/hooks/kpt-activity-log.sh
@@ -15,8 +15,9 @@ INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
-# アシスタントの応答を500文字に切り詰め
-ASSISTANT_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""' | head -c 500)
+# アシスタントの応答を redaction → 500文字切り詰め
+ASSISTANT_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""' \
+  | bash "$(dirname "$0")/kpt-redact.sh" | head -c 500)
 
 # stop_hook_active なら無限ループ防止
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // "false"')

--- a/.claude/hooks/kpt-activity-log.sh
+++ b/.claude/hooks/kpt-activity-log.sh
@@ -15,9 +15,16 @@ INPUT=$(cat)
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
-# アシスタントの応答を redaction → 500文字切り詰め
-ASSISTANT_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""' \
-  | bash "$(dirname "$0")/kpt-redact.sh" | head -c 500)
+# アシスタントの応答を redaction → 500文字切り詰め。
+# redact 失敗時は fail-closed で [REDACTION_FAILED] マーカーに倒し、未 redact の
+# 生メッセージがディスクに残らないようにする（pipe 先で truncate する前に全量 redact）。
+REDACT_SH="$(dirname "$0")/kpt-redact.sh"
+ASSISTANT_RAW=$(echo "$INPUT" | jq -r '.last_assistant_message // ""')
+if [ -x "$REDACT_SH" ] && ASSISTANT_REDACTED=$(printf '%s' "$ASSISTANT_RAW" | bash "$REDACT_SH" 2>/dev/null); then
+  ASSISTANT_MSG=$(printf '%s' "$ASSISTANT_REDACTED" | head -c 500)
+else
+  ASSISTANT_MSG="[REDACTION_FAILED]"
+fi
 
 # stop_hook_active なら無限ループ防止
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // "false"')

--- a/.claude/hooks/kpt-redact.sh
+++ b/.claude/hooks/kpt-redact.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# =============================================================================
+# Secret Redaction Filter (stdin → stdout)
+# 配置先: ~/.claude/hooks/kpt-redact.sh
+#
+# ディスク書き込みおよび Anthropic API 送信の前段で、既知の機密パターン
+# を [REDACTED_*] トークンに置換する。防御の第一層であり、完全な検出を
+# 保証するものではない（ディスク暗号化等の併用を推奨）。
+# =============================================================================
+
+set -euo pipefail
+
+# 1. PRIVATE KEY ブロック（複数行）を単一行マーカーに潰す
+# 2. その後、単一行パターンを順次置換する（sed -E / POSIX ERE）
+sed -E '
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,/-----END [A-Z ]*PRIVATE KEY-----/{
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/c\
+[REDACTED_PRIVATE_KEY]
+    d
+  }
+' | sed -E \
+    -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED_ANTHROPIC_KEY]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{50,}/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/ghp_[A-Za-z0-9]{36,}/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/AKIA[0-9A-Z]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+    -e 's/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[REDACTED_JWT]/g' \
+    -e 's/xox[baprs]-[A-Za-z0-9-]+/[REDACTED_SLACK_TOKEN]/g' \
+    -e 's/(password|secret|api[-_]?key|token)[[:space:]]*[:=][[:space:]]*"[^"]{8,}"/\1=[REDACTED]/gI' \
+  | sed -E "s/(password|secret|api[-_]?key|token)[[:space:]]*[:=][[:space:]]*'[^']{8,}'/\1=[REDACTED]/gI"

--- a/.claude/hooks/kpt-redact.sh
+++ b/.claude/hooks/kpt-redact.sh
@@ -20,10 +20,13 @@ sed -E '
   }
 ' | sed -E \
     -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED_ANTHROPIC_KEY]/g' \
+    -e 's/sk-proj-[A-Za-z0-9_-]{20,}/[REDACTED_OPENAI_KEY]/g' \
     -e 's/github_pat_[A-Za-z0-9_]{50,}/[REDACTED_GITHUB_TOKEN]/g' \
-    -e 's/ghp_[A-Za-z0-9]{36,}/[REDACTED_GITHUB_TOKEN]/g' \
-    -e 's/AKIA[0-9A-Z]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+    -e 's/gh[pousr]_[A-Za-z0-9]{36,}/[REDACTED_GITHUB_TOKEN]/g' \
+    -e 's/(AKIA|ASIA)[0-9A-Z]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+    -e 's/AIza[0-9A-Za-z_-]{35,}/[REDACTED_GOOGLE_API_KEY]/g' \
+    -e 's/(sk|pk|rk)_(live|test)_[0-9a-zA-Z]{24,}/[REDACTED_STRIPE_KEY]/g' \
     -e 's/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/[REDACTED_JWT]/g' \
-    -e 's/xox[baprs]-[A-Za-z0-9-]+/[REDACTED_SLACK_TOKEN]/g' \
+    -e 's/xox[baprs]-[A-Za-z0-9-]{10,200}/[REDACTED_SLACK_TOKEN]/g' \
     -e 's/(password|secret|api[-_]?key|token)[[:space:]]*[:=][[:space:]]*"[^"]{8,}"/\1=[REDACTED]/gI' \
   | sed -E "s/(password|secret|api[-_]?key|token)[[:space:]]*[:=][[:space:]]*'[^']{8,}'/\1=[REDACTED]/gI"

--- a/.claude/hooks/kpt-session-analyze.sh
+++ b/.claude/hooks/kpt-session-analyze.sh
@@ -72,6 +72,14 @@ INPUT=$(cat)
     end
   ' "$TRANSCRIPT_PATH" 2>/dev/null > "$PROMPT_FILE"
 
+  # Anthropic API に送信する前に既知の機密パターンを [REDACTED_*] に置換
+  REDACTED_TMP=$(mktemp)
+  if bash "$(dirname "$0")/kpt-redact.sh" < "$PROMPT_FILE" > "$REDACTED_TMP" 2>/dev/null; then
+    mv "$REDACTED_TMP" "$PROMPT_FILE"
+  else
+    rm -f "$REDACTED_TMP"
+  fi
+
   cat > "$ANALYSIS_PROMPT" << PROMPT_END
 あなたはClaude Codeの自己分析AIです。
 以下はClaude Codeのセッションログです。**Claude Code自身の視点**で振り返り、自分が何を間違えたか、何を改善すべきかを分析してください。

--- a/.claude/hooks/kpt-session-analyze.sh
+++ b/.claude/hooks/kpt-session-analyze.sh
@@ -72,12 +72,27 @@ INPUT=$(cat)
     end
   ' "$TRANSCRIPT_PATH" 2>/dev/null > "$PROMPT_FILE"
 
-  # Anthropic API に送信する前に既知の機密パターンを [REDACTED_*] に置換
+  # Anthropic API に送信する前に既知の機密パターンを [REDACTED_*] に置換。
+  # redaction が失敗した場合は fail-closed: 未 redact のまま送信するのを避け、
+  # セッション分析そのものを中止する。hook は background 実行で stderr が捨てられるため、
+  # 気付けるように OUTPUT_FILE にエラーマーカーを書き、ダッシュボード側で検知させる。
+  REDACT_SH="$(dirname "$0")/kpt-redact.sh"
   REDACTED_TMP=$(mktemp)
-  if bash "$(dirname "$0")/kpt-redact.sh" < "$PROMPT_FILE" > "$REDACTED_TMP" 2>/dev/null; then
+  if [ -x "$REDACT_SH" ] && bash "$REDACT_SH" < "$PROMPT_FILE" > "$REDACTED_TMP" 2>/dev/null; then
     mv "$REDACTED_TMP" "$PROMPT_FILE"
   else
-    rm -f "$REDACTED_TMP"
+    rm -f "$REDACTED_TMP" "$PROMPT_FILE" "$ANALYSIS_PROMPT"
+    {
+      echo "# 自己分析: ${PROJECT_NAME} (${TODAY}) — ABORTED"
+      echo ""
+      echo "## 中止理由"
+      echo "\`kpt-redact.sh\` の実行に失敗したため、transcript の Anthropic API 送信を fail-closed で中止しました。"
+      echo ""
+      echo "- Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+      echo "- Session: ${SESSION_ID}"
+      echo "- 再現: \`bash ~/.claude/hooks/kpt-redact.sh < /some/input\`"
+    } > "$OUTPUT_FILE"
+    exit 0
   fi
 
   cat > "$ANALYSIS_PROMPT" << PROMPT_END

--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ sleep 15 && ls -la ~/.claude/kpt-data/session-reviews/
 
 - Stop hook の activity-log はローカルファイルに JSONL を追記するだけで、API 呼び出しを一切行わない。
 
+## Privacy & Security
+
+会話には API キー / トークン等を誤って貼り付けるリスクが付きまとう。本システムはディスク書き込みおよび Anthropic API 送信の**前段**で自動 redaction をかける。
+
+### 自動 redaction
+
+`.claude/hooks/kpt-redact.sh` が stdin → stdout フィルタとして以下を置換する：
+
+| パターン | 置換先 |
+| --- | --- |
+| `sk-ant-...` | `[REDACTED_ANTHROPIC_KEY]` |
+| `ghp_...` / `github_pat_...` | `[REDACTED_GITHUB_TOKEN]` |
+| `AKIA[0-9A-Z]{16}` | `[REDACTED_AWS_ACCESS_KEY]` |
+| `-----BEGIN ... PRIVATE KEY-----` ブロック（複数行） | `[REDACTED_PRIVATE_KEY]` |
+| `eyJ....eyJ....<sig>` (JWT) | `[REDACTED_JWT]` |
+| `xox[baprs]-...` (Slack) | `[REDACTED_SLACK_TOKEN]` |
+| `(password\|secret\|api[_-]?key\|token) = "..."` (8+文字、大小区別なし) | `<key>=[REDACTED]` |
+
+適用箇所：
+
+- **Stop hook (`kpt-activity-log.sh`)** — `last_assistant_message` を redact → 500 文字切り詰めして JSONL に追記
+- **SessionEnd hook (`kpt-session-analyze.sh`)** — transcript 抽出後、Anthropic API に送信する**前**に redact
+
+### フルディスク暗号化の推奨
+
+redaction は既知パターンの第一層防御であり、パターン外の機密（独自形式の API キー等）は捉えられない。セッションログや KPT 全文はローカルディスクに残るため、**フルディスク暗号化 (FDE) の有効化を強く推奨する**：
+
+- **macOS**: FileVault
+- **Windows**: BitLocker
+- **Linux**: LUKS
+
+### スコープ外（別 issue 予定）
+
+- ファイル単位暗号化（gpg / age）
+- プロジェクト単位の allowlist / denylist
+- SessionEnd hook のオフスイッチ（現状は `settings.json` の手動編集で代替可能）
+
 ## Cost Tracking
 
 推測値ではなく**実測値**で管理する。SessionEnd hook は `claude -p --output-format json` で Haiku を呼び、応答 JSON の `usage` / `total_cost_usd` / `duration_ms` を `~/.claude/kpt-data/cost-logs/cost_YYYY-MM.jsonl` に記録する。

--- a/README.md
+++ b/README.md
@@ -188,17 +188,56 @@ sleep 15 && ls -la ~/.claude/kpt-data/session-reviews/
 | パターン | 置換先 |
 | --- | --- |
 | `sk-ant-...` | `[REDACTED_ANTHROPIC_KEY]` |
-| `ghp_...` / `github_pat_...` | `[REDACTED_GITHUB_TOKEN]` |
-| `AKIA[0-9A-Z]{16}` | `[REDACTED_AWS_ACCESS_KEY]` |
+| `sk-proj-...` (OpenAI project key) | `[REDACTED_OPENAI_KEY]` |
+| `ghp_` / `gho_` / `ghu_` / `ghs_` / `ghr_` / `github_pat_` | `[REDACTED_GITHUB_TOKEN]` |
+| `AKIA[0-9A-Z]{16}` / `ASIA...` (AWS IAM / STS) | `[REDACTED_AWS_ACCESS_KEY]` |
+| `AIza[0-9A-Za-z_-]{35,}` (Google API) | `[REDACTED_GOOGLE_API_KEY]` |
+| `sk_live_` / `sk_test_` / `pk_live_` / `pk_test_` / `rk_...` (Stripe) | `[REDACTED_STRIPE_KEY]` |
 | `-----BEGIN ... PRIVATE KEY-----` ブロック（複数行） | `[REDACTED_PRIVATE_KEY]` |
 | `eyJ....eyJ....<sig>` (JWT) | `[REDACTED_JWT]` |
-| `xox[baprs]-...` (Slack) | `[REDACTED_SLACK_TOKEN]` |
+| `xox[baprs]-...` (Slack, 10–200 文字) | `[REDACTED_SLACK_TOKEN]` |
 | `(password\|secret\|api[_-]?key\|token) = "..."` (8+文字、大小区別なし) | `<key>=[REDACTED]` |
 
 適用箇所：
 
 - **Stop hook (`kpt-activity-log.sh`)** — `last_assistant_message` を redact → 500 文字切り詰めして JSONL に追記
 - **SessionEnd hook (`kpt-session-analyze.sh`)** — transcript 抽出後、Anthropic API に送信する**前**に redact
+
+### fail-closed 動作
+
+redaction スクリプトが欠落 / エラーで失敗した場合、**未 redact データを露出させないこと**を優先する：
+
+- **Stop hook** — `message` フィールドを `[REDACTION_FAILED]` マーカーで JSONL に追記
+- **SessionEnd hook** — API 送信を中止し、session-reviews に `ABORTED` マーカー付き自己分析ファイルを書き出す（ダッシュボード Self-Reviews タブで検知可能）
+
+### 副作用と制約
+
+- **over-redact 優先の設計**: 誤検知（例えば本文中の `secret = "something"` が `secret=[REDACTED]` になる）は許容する。under-redact で機密を漏らすよりマシという判断
+- **カバー範囲は既知パターンのみ**: 独自形式の API キー、社内トークン、短い認証情報（< 8 文字）は捉えられない。網羅的な DLP にはならない
+- **sed の case-insensitive (`gI`) フラグは GNU 拡張**: macOS Sonoma 以降は動作する。古い BSD sed では代入パターンの大文字マッチが効かない可能性あり
+- **session-review の分析品質**: transcript の一部が `[REDACTED_*]` に置換されるため、Haiku が返す分析文の文脈解釈が若干劣化する可能性
+
+### 無効化したい場合
+
+デバッグ等で redaction を外したい場合：
+
+```bash
+# 恒久的に無効化（バックアップを取りつつ cat で通す空フィルタに置き換え）
+cp ~/.claude/hooks/kpt-redact.sh ~/.claude/hooks/kpt-redact.sh.bak
+cat > ~/.claude/hooks/kpt-redact.sh <<'EOF'
+#!/bin/bash
+exec cat
+EOF
+chmod +x ~/.claude/hooks/kpt-redact.sh
+```
+
+復旧は `mv ~/.claude/hooks/kpt-redact.sh.bak ~/.claude/hooks/kpt-redact.sh`。
+
+### テスト
+
+```bash
+bash test/test-redact.sh   # 27 パターンのフィクスチャテスト
+```
 
 ### フルディスク暗号化の推奨
 

--- a/README.md
+++ b/README.md
@@ -179,79 +179,11 @@ sleep 15 && ls -la ~/.claude/kpt-data/session-reviews/
 
 ## Privacy & Security
 
-会話には API キー / トークン等を誤って貼り付けるリスクが付きまとう。本システムはディスク書き込みおよび Anthropic API 送信の**前段**で自動 redaction をかける。
+会話に誤って貼り付けた API キー / トークンをディスク書き込みと Anthropic API 送信の**前段**で自動 redaction する。対応パターンは Anthropic / OpenAI / GitHub / AWS / Google / Stripe / Slack / JWT / PRIVATE KEY ブロック / `password=...` 形式の代入。詳細は `.claude/hooks/kpt-redact.sh` 冒頭コメントを参照。
 
-### 自動 redaction
+redaction が失敗した場合は fail-closed — 未 redact データを送信せず、マーカー（`[REDACTION_FAILED]` / `ABORTED`）を残して後から検知可能にする。
 
-`.claude/hooks/kpt-redact.sh` が stdin → stdout フィルタとして以下を置換する：
-
-| パターン | 置換先 |
-| --- | --- |
-| `sk-ant-...` | `[REDACTED_ANTHROPIC_KEY]` |
-| `sk-proj-...` (OpenAI project key) | `[REDACTED_OPENAI_KEY]` |
-| `ghp_` / `gho_` / `ghu_` / `ghs_` / `ghr_` / `github_pat_` | `[REDACTED_GITHUB_TOKEN]` |
-| `AKIA[0-9A-Z]{16}` / `ASIA...` (AWS IAM / STS) | `[REDACTED_AWS_ACCESS_KEY]` |
-| `AIza[0-9A-Za-z_-]{35,}` (Google API) | `[REDACTED_GOOGLE_API_KEY]` |
-| `sk_live_` / `sk_test_` / `pk_live_` / `pk_test_` / `rk_...` (Stripe) | `[REDACTED_STRIPE_KEY]` |
-| `-----BEGIN ... PRIVATE KEY-----` ブロック（複数行） | `[REDACTED_PRIVATE_KEY]` |
-| `eyJ....eyJ....<sig>` (JWT) | `[REDACTED_JWT]` |
-| `xox[baprs]-...` (Slack, 10–200 文字) | `[REDACTED_SLACK_TOKEN]` |
-| `(password\|secret\|api[_-]?key\|token) = "..."` (8+文字、大小区別なし) | `<key>=[REDACTED]` |
-
-適用箇所：
-
-- **Stop hook (`kpt-activity-log.sh`)** — `last_assistant_message` を redact → 500 文字切り詰めして JSONL に追記
-- **SessionEnd hook (`kpt-session-analyze.sh`)** — transcript 抽出後、Anthropic API に送信する**前**に redact
-
-### fail-closed 動作
-
-redaction スクリプトが欠落 / エラーで失敗した場合、**未 redact データを露出させないこと**を優先する：
-
-- **Stop hook** — `message` フィールドを `[REDACTION_FAILED]` マーカーで JSONL に追記
-- **SessionEnd hook** — API 送信を中止し、session-reviews に `ABORTED` マーカー付き自己分析ファイルを書き出す（ダッシュボード Self-Reviews タブで検知可能）
-
-### 副作用と制約
-
-- **over-redact 優先の設計**: 誤検知（例えば本文中の `secret = "something"` が `secret=[REDACTED]` になる）は許容する。under-redact で機密を漏らすよりマシという判断
-- **カバー範囲は既知パターンのみ**: 独自形式の API キー、社内トークン、短い認証情報（< 8 文字）は捉えられない。網羅的な DLP にはならない
-- **sed の case-insensitive (`gI`) フラグは GNU 拡張**: macOS Sonoma 以降は動作する。古い BSD sed では代入パターンの大文字マッチが効かない可能性あり
-- **session-review の分析品質**: transcript の一部が `[REDACTED_*]` に置換されるため、Haiku が返す分析文の文脈解釈が若干劣化する可能性
-
-### 無効化したい場合
-
-デバッグ等で redaction を外したい場合：
-
-```bash
-# 恒久的に無効化（バックアップを取りつつ cat で通す空フィルタに置き換え）
-cp ~/.claude/hooks/kpt-redact.sh ~/.claude/hooks/kpt-redact.sh.bak
-cat > ~/.claude/hooks/kpt-redact.sh <<'EOF'
-#!/bin/bash
-exec cat
-EOF
-chmod +x ~/.claude/hooks/kpt-redact.sh
-```
-
-復旧は `mv ~/.claude/hooks/kpt-redact.sh.bak ~/.claude/hooks/kpt-redact.sh`。
-
-### テスト
-
-```bash
-bash test/test-redact.sh   # 27 パターンのフィクスチャテスト
-```
-
-### フルディスク暗号化の推奨
-
-redaction は既知パターンの第一層防御であり、パターン外の機密（独自形式の API キー等）は捉えられない。セッションログや KPT 全文はローカルディスクに残るため、**フルディスク暗号化 (FDE) の有効化を強く推奨する**：
-
-- **macOS**: FileVault
-- **Windows**: BitLocker
-- **Linux**: LUKS
-
-### スコープ外（別 issue 予定）
-
-- ファイル単位暗号化（gpg / age）
-- プロジェクト単位の allowlist / denylist
-- SessionEnd hook のオフスイッチ（現状は `settings.json` の手動編集で代替可能）
+既知パターンの第一層防御にすぎず、独自形式のキーや短い認証情報は捉えられない。**フルディスク暗号化 (FileVault / BitLocker / LUKS) の併用を強く推奨する**。
 
 ## Cost Tracking
 

--- a/install.sh
+++ b/install.sh
@@ -38,8 +38,10 @@ mkdir -p "$CLAUDE_DIR/kpt-data/cost-logs"
 echo "[2/6] Installing hooks..."
 cp "$SCRIPT_DIR/.claude/hooks/kpt-activity-log.sh" "$CLAUDE_DIR/hooks/"
 cp "$SCRIPT_DIR/.claude/hooks/kpt-session-analyze.sh" "$CLAUDE_DIR/hooks/"
+cp "$SCRIPT_DIR/.claude/hooks/kpt-redact.sh" "$CLAUDE_DIR/hooks/"
 chmod +x "$CLAUDE_DIR/hooks/kpt-activity-log.sh"
 chmod +x "$CLAUDE_DIR/hooks/kpt-session-analyze.sh"
+chmod +x "$CLAUDE_DIR/hooks/kpt-redact.sh"
 
 # 3. Skills
 echo "[3/6] Installing skills..."

--- a/test/test-redact.sh
+++ b/test/test-redact.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# =============================================================================
+# kpt-redact.sh のフィクスチャテスト
+# Usage: bash test/test-redact.sh
+#
+# 注意: フィクスチャのトークンリテラルは GitHub Push Protection に検出される
+# ため、プレフィックスと本体を分割連結して擬似生成する。
+# =============================================================================
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REDACT="$SCRIPT_DIR/.claude/hooks/kpt-redact.sh"
+PASS=0
+FAIL=0
+
+# トークンフィクスチャ生成ヘルパー（プレフィックスと本体を分割してリテラル検出を回避）
+mk() { printf '%s%s' "$1" "$2"; }
+
+check() {
+  local name="$1" input="$2" expected="$3"
+  local got
+  got=$(printf '%s' "$input" | bash "$REDACT") || {
+    echo "FAIL: $name (redact exited non-zero)"
+    FAIL=$((FAIL+1))
+    return
+  }
+  if [ "$got" = "$expected" ]; then
+    echo "PASS: $name"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL: $name"
+    echo "  input:    $input"
+    echo "  expected: $expected"
+    echo "  got:      $got"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "=== kpt-redact.sh tests ==="
+
+# --- 既知トークンパターン ---
+check "Anthropic key"            "$(mk 'sk-ant-' 'api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123')" "[REDACTED_ANTHROPIC_KEY]"
+check "OpenAI project key"       "$(mk 'sk-proj-' 'abcdefghijklmnopqrstuvwxyz0123')"      "[REDACTED_OPENAI_KEY]"
+check "GitHub classic (ghp_)"    "$(mk 'ghp_' 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ZXYW')" "[REDACTED_GITHUB_TOKEN]"
+check "GitHub OAuth (gho_)"      "$(mk 'gho_' 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ZXYW')" "[REDACTED_GITHUB_TOKEN]"
+check "GitHub user-server (ghu_)" "$(mk 'ghu_' 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ZXYW')" "[REDACTED_GITHUB_TOKEN]"
+check "GitHub server-server (ghs_)" "$(mk 'ghs_' 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789ZXYW')" "[REDACTED_GITHUB_TOKEN]"
+check "GitHub fine-grained PAT"  "$(mk 'github_pat_' '11ABCDEFG0abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ_ab')" "[REDACTED_GITHUB_TOKEN]"
+check "AWS access key"           "$(mk 'AKIA' 'IOSFODNN7EXAMPLE')"                        "[REDACTED_AWS_ACCESS_KEY]"
+check "AWS STS temp key"         "$(mk 'ASIA' 'IOSFODNN7EXAMPLE')"                        "[REDACTED_AWS_ACCESS_KEY]"
+check "Google API key"           "$(mk 'AIza' 'SyA-abcdefghijklmnopqrstuvwxyz0123456')"   "[REDACTED_GOOGLE_API_KEY]"
+check "Stripe live secret"       "$(mk 'sk_live_' 'abcdefghijklmnopqrstuvwx')"            "[REDACTED_STRIPE_KEY]"
+check "Stripe test publishable"  "$(mk 'pk_test_' 'abcdefghijklmnopqrstuvwx')"            "[REDACTED_STRIPE_KEY]"
+check "JWT"                      "$(mk 'eyJ' 'hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.abc')" "[REDACTED_JWT]"
+check "Slack bot token"          "$(mk 'xoxb-' '1234567890-aBcDeFgHiJkL')"                "[REDACTED_SLACK_TOKEN]"
+check "Slack user token"         "$(mk 'xoxp-' '1234567890-aBcDeFgHiJkLmNoPqR')"          "[REDACTED_SLACK_TOKEN]"
+
+# --- 代入（大小混在 / クォート別） ---
+check "password double-quoted"   'password="supersecretvalue"'                  'password=[REDACTED]'
+check "API_KEY uppercase"        'API_KEY="verylongsecret12345"'                'API_KEY=[REDACTED]'
+check "Password colon"           'Password: "supersecrethere"'                  'Password=[REDACTED]'
+check "token single-quoted"      "TOKEN='anothersecretlongone'"                 "TOKEN=[REDACTED]"
+check "api-key mixed case"       'Api-Key="abcdefghijklmnop"'                   'Api-Key=[REDACTED]'
+
+# --- 複数行 PRIVATE KEY ---
+multi_in=$'-----BEGIN RSA PRIVATE KEY-----\nxxxxxxx\nyyyyyyy\n-----END RSA PRIVATE KEY-----'
+check "PRIVATE KEY block"        "$multi_in" "[REDACTED_PRIVATE_KEY]"
+
+ec_in=$'-----BEGIN EC PRIVATE KEY-----\naaaa\n-----END EC PRIVATE KEY-----'
+check "EC PRIVATE KEY block"     "$ec_in" "[REDACTED_PRIVATE_KEY]"
+
+# --- Slack greedy 回避: 後続の非トークン text は残る ---
+check "Slack token not greedy"   "$(mk 'xoxb-' '1234567890-aBcDeFgHiJkL') and more text" "[REDACTED_SLACK_TOKEN] and more text"
+
+# --- インライン混在 ---
+check "Anthropic inline in prose" "use the token $(mk 'sk-ant-' 'api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567') here" \
+                                  "use the token [REDACTED_ANTHROPIC_KEY] here"
+
+# --- 正常テキストは保持 ---
+check "plain text untouched"     "this is normal text with nothing to redact"   "this is normal text with nothing to redact"
+check "short password kept"      'pwd="abc"'                                    'pwd="abc"'
+check "random base64-like kept"  "randomBase64StringNotAJWTOrKey"               "randomBase64StringNotAJWTOrKey"
+
+echo ""
+echo "=== Result: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,6 +68,7 @@ fi
 echo "[2/6] Removing hooks ..."
 rm -f "$CLAUDE_DIR/hooks/kpt-activity-log.sh"
 rm -f "$CLAUDE_DIR/hooks/kpt-session-analyze.sh"
+rm -f "$CLAUDE_DIR/hooks/kpt-redact.sh"
 
 # 3. Skills
 echo "[3/6] Removing skills ..."


### PR DESCRIPTION
Closes #4

## Summary
- `.claude/hooks/kpt-redact.sh` を新規追加。stdin → stdout の sed ベースフィルタで既知の機密パターンを `[REDACTED_*]` に置換する
- **Stop hook**: `last_assistant_message` を redact → 500 文字切り詰めして JSONL に追記
- **SessionEnd hook**: transcript 抽出後、Anthropic API に送信する**前**に redact を適用
- `install.sh` / `uninstall.sh` に `kpt-redact.sh` の配置 / 削除を追加
- README に Privacy & Security セクションを追加（redaction 適用箇所・FDE 推奨）

## 対応パターン

| Input | 置換先 |
| --- | --- |
| `sk-ant-[A-Za-z0-9_-]{20,}` | `[REDACTED_ANTHROPIC_KEY]` |
| `ghp_[A-Za-z0-9]{36,}` / `github_pat_[A-Za-z0-9_]{50,}` | `[REDACTED_GITHUB_TOKEN]` |
| `AKIA[0-9A-Z]{16}` | `[REDACTED_AWS_ACCESS_KEY]` |
| `-----BEGIN ... PRIVATE KEY-----` ブロック（複数行） | `[REDACTED_PRIVATE_KEY]` |
| JWT (`eyJ....eyJ....<sig>`) | `[REDACTED_JWT]` |
| `xox[baprs]-...` (Slack) | `[REDACTED_SLACK_TOKEN]` |
| `(password\|secret\|api[_-]?key\|token)\s*[:=]\s*"..."` (8+文字、大小区別なし) | `<key>=[REDACTED]` |

## 受け入れ基準
- [x] `kpt-redact.sh` がサンプル機密入力に対して全パターン redact できる（統合テストで確認）
- [x] 両 hook が redaction 後のデータのみをディスク / API に渡している
- [x] README に Privacy & Security セクションが存在する
- [x] `install.sh` でスクリプトが配置される
- [x] `uninstall.sh` でスクリプトが除去される

## Test plan
- [x] kpt-redact.sh 直接呼び出しで 7 パターン全て置換されることを確認
- [x] Stop hook に機密入り stdin を渡し、JSONL の message フィールドで redact されていることを確認
- [x] PRIVATE KEY の複数行ブロックが単一 `[REDACTED_PRIVATE_KEY]` マーカーに潰されることを確認
- [x] 大文字パターン (`API_KEY`, `TOKEN`, `Password:` 等) も case-insensitive flag で redact されることを確認

## スコープ外（別 issue 予定）
- ファイル単位暗号化（gpg / age）
- プロジェクト単位の allowlist / denylist
- SessionEnd hook のオフスイッチ（現状は settings.json の手動編集で代替可）